### PR TITLE
Update to remove the SAVE command

### DIFF
--- a/cli/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.cpp
+++ b/cli/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.cpp
@@ -536,7 +536,7 @@ bool CryptoNoteProtocolHandler::on_connection_synchronized() {
       << "You are now synchronized with the network. " << ENDL
       << "Use \"help\" command to see the list of available options." << ENDL
       << "The blockchain will be saved only after you quit the " << ENDL
-      << "daemon with \"exit\" command or if you use \"save\" command." << ENDL
+      << "daemon with \"exit\" command, or if you cancel the process using CTRL-C." << ENDL
       << "****************************************************************" << ENDL
       << ENDL ;
     m_core.on_synchronized();


### PR DESCRIPTION
Clarification in logger to the user that the "save" command does not exist anymore .

"existía cuando el archivo se leía desde la memoria (caché), ahora se lee-escribe directo del disco. Como los pendrives que se pueden extraer "inseguramente" "